### PR TITLE
feat: Implement Breaker Registration & Refine Breaker Table

### DIFF
--- a/src/components/breakers/breaker-management-table.tsx
+++ b/src/components/breakers/breaker-management-table.tsx
@@ -14,6 +14,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { useBreakers } from "@/hooks/use-breakers";
 import { Skeleton } from "@/components/ui/skeleton";
 import { type Breaker } from "@/types/breakers";
+import React from "react"; // Import React to use React.Fragment
 
 interface ExpandedBreaker extends Breaker {
   isExpanded: boolean;
@@ -210,9 +211,10 @@ export function BreakerManagementTable() {
           </TableHeader>
           <TableBody>
             {breakers.map((breaker) => (
-              <>
+              // --- KEY ADDED TO REACT.FRAGMENT ---
+              <React.Fragment key={breaker.id}>
                 <TableRow
-                  key={breaker.id}
+                  // No need for key here, as the parent Fragment has it
                   className="cursor-pointer hover:bg-gray-50"
                   onClick={() => toggleExpandBreaker(breaker.id)}
                 >
@@ -230,11 +232,10 @@ export function BreakerManagementTable() {
                   </TableCell>
                   <TableCell>
                     <span
-                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                        breaker.status === "Active"
+                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${breaker.status === "Active"
                           ? "bg-green-100 text-green-800"
                           : "bg-red-100 text-red-800"
-                      }`}
+                        }`}
                     >
                       {breaker.status}
                     </span>
@@ -252,7 +253,7 @@ export function BreakerManagementTable() {
                           .filter(([_, show]) => show)
                           .map(([btnId, isActive]) => (
                             <Button
-                              key={btnId}
+                              key={btnId} // This key was already correct
                               variant={isActive ? "default" : "outline"}
                               className={
                                 isActive
@@ -268,7 +269,7 @@ export function BreakerManagementTable() {
                     </TableCell>
                   </TableRow>
                 )}
-              </>
+              </React.Fragment>
             ))}
           </TableBody>
         </Table>

--- a/src/components/breakers/create-breaker-form.tsx
+++ b/src/components/breakers/create-breaker-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type React from "react";
-
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,34 +12,67 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useRegisterBreaker } from "@/hooks/use-breakers";
+import { toast } from "sonner";
 
 interface FormData {
   sbcId: string;
-  location: string;
-  sbcName: string;
-  numberOfBreakers: string;
-  position: string;
-  operator: string;
+  state: string;
+  name: string;
+  breakerCounter: string;
+  city: string;
+  streetName: string;
+  assetId: string;
 }
 
 const numberOfBreakersOptions = ["1", "2", "3", "4", "5", "6"];
-const positionOptions = ["Manager", "Supervisor", "Operator"];
-const operatorOptions = ["John Doe", "Jane Smith", "Mike Johnson"];
 
 export function CreateBreakerForm() {
   const [formData, setFormData] = useState<FormData>({
     sbcId: "",
-    location: "",
-    sbcName: "",
-    numberOfBreakers: "",
-    position: "",
-    operator: "",
+    state: "",
+    city: "",
+    streetName: "",
+    name: "",
+    breakerCounter: "",
+    assetId: "",
   });
+
+  const { mutate: registerBreakerMutation, isPending } = useRegisterBreaker();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Form submitted:", formData);
-    // Handle form submission
+
+    // Create a new payload object that matches backend expectations
+    const payloadForApi = {
+      sbcId: formData.sbcId,
+      name: formData.name,
+      assetId: formData.assetId,
+      state: formData.state,
+      breakerCount: parseInt(formData.breakerCounter, 10), // Convert to number
+      streetName: formData.streetName,
+      city: formData.city,
+    };
+
+    registerBreakerMutation(payloadForApi, { // Pass the adjusted payload
+      onSuccess: () => {
+        toast.success("Breaker registered successfully!");
+        // Optionally reset the form after successful submission
+        setFormData({
+          sbcId: "",
+          state: "",
+          city: "",
+          streetName: "",
+          name: "",
+          breakerCounter: "",
+          assetId: "",
+        });
+      },
+      onError: (error) => {
+        console.error("Error registering breaker:", error); // Log the full error object for more details
+        toast.error(`Failed to register breaker: ${error.message}`);
+      },
+    });
   };
 
   return (
@@ -62,16 +94,46 @@ export function CreateBreakerForm() {
       </div>
 
       <div className="space-y-3">
-        <Label htmlFor="location" className="text-lg">
-          Location
+        <Label htmlFor="state" className="text-lg">
+          State
         </Label>
         <Input
-          id="location"
-          value={formData.location}
+          id="state"
+          value={formData.state}
           onChange={(e) =>
-            setFormData((prev) => ({ ...prev, location: e.target.value }))
+            setFormData((prev) => ({ ...prev, state: e.target.value }))
           }
-          placeholder="Enter location"
+          placeholder="Enter State"
+          required
+          className="text-lg"
+        />
+      </div>
+      <div className="space-y-3">
+        <Label htmlFor="city" className="text-lg">
+          City
+        </Label>
+        <Input
+          id="city"
+          value={formData.city}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, city: e.target.value }))
+          }
+          placeholder="Enter City"
+          required
+          className="text-lg"
+        />
+      </div>
+      <div className="space-y-3">
+        <Label htmlFor="streetName" className="text-lg">
+          Street Name
+        </Label>
+        <Input
+          id="streetName" // Corrected ID
+          value={formData.streetName} // Corrected value
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, streetName: e.target.value }))
+          }
+          placeholder="Enter The Street Name"
           required
           className="text-lg"
         />
@@ -83,9 +145,9 @@ export function CreateBreakerForm() {
         </Label>
         <Input
           id="sbcName"
-          value={formData.sbcName}
+          value={formData.name}
           onChange={(e) =>
-            setFormData((prev) => ({ ...prev, sbcName: e.target.value }))
+            setFormData((prev) => ({ ...prev, name: e.target.value }))
           }
           placeholder="Enter SBC name"
           required
@@ -94,13 +156,13 @@ export function CreateBreakerForm() {
       </div>
 
       <div className="space-y-3">
-        <Label htmlFor="numberOfBreakers" className="text-lg">
-          Number Of Breakers
+        <Label htmlFor="numberOfBreaker" className="text-lg">
+          Breaker counter
         </Label>
         <Select
-          value={formData.numberOfBreakers}
+          value={formData.breakerCounter}
           onValueChange={(value) =>
-            setFormData((prev) => ({ ...prev, numberOfBreakers: value }))
+            setFormData((prev) => ({ ...prev, breakerCounter: value }))
           }
         >
           <SelectTrigger id="numberOfBreakers">
@@ -117,53 +179,27 @@ export function CreateBreakerForm() {
       </div>
 
       <div className="space-y-3">
-        <Label htmlFor="position" className="text-lg">
-          Select Position In Organization
+        <Label htmlFor="assetId" className="text-lg">
+          Enter the Asset Id
         </Label>
-        <Select
-          value={formData.position}
-          onValueChange={(value) =>
-            setFormData((prev) => ({ ...prev, position: value }))
+        <Input
+          id="assetId"
+          value={formData.assetId}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, assetId: e.target.value }))
           }
-        >
-          <SelectTrigger id="position">
-            <SelectValue placeholder="Select position" />
-          </SelectTrigger>
-          <SelectContent>
-            {positionOptions.map((option) => (
-              <SelectItem key={option} value={option}>
-                {option}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          placeholder="Enter Asset Id"
+          required
+          className="text-lg"
+        />
       </div>
 
-      <div className="space-y-3">
-        <Label htmlFor="operator" className="text-lg">
-          Assigned Operator
-        </Label>
-        <Select
-          value={formData.operator}
-          onValueChange={(value) =>
-            setFormData((prev) => ({ ...prev, operator: value }))
-          }
-        >
-          <SelectTrigger id="operator">
-            <SelectValue placeholder="Select operator" />
-          </SelectTrigger>
-          <SelectContent>
-            {operatorOptions.map((option) => (
-              <SelectItem key={option} value={option}>
-                {option}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <Button type="submit" className="bg-purple-600 hover:bg-purple-700">
-        Create Breaker
+      <Button
+        type="submit"
+        className="bg-purple-600 hover:bg-purple-700"
+        disabled={isPending} // Disable button while the mutation is pending
+      >
+        {isPending ? "Creating Breaker..." : "Create Breaker"}
       </Button>
     </form>
   );

--- a/src/hooks/use-breakers.ts
+++ b/src/hooks/use-breakers.ts
@@ -1,7 +1,17 @@
-import { useQuery } from "@tanstack/react-query";
-import { fetchBreakers } from "@/services/breakers-service";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  fetchBreakers,
+  type RegisterBreakerPayload,
+  type RegisterBreakerResponse,
+} from "@/services/breakers-service"; // Make sure to import the new types
 import { type Breaker, type BreakerFilters } from "@/types/breakers";
 import { useAuth } from "@/context/auth-context";
+import axios from "axios";
+import { env } from "@/env";
+import { handleApiError } from "error";
+
+const API_BASE_URL = env.NEXT_PUBLIC_BASE_URL;
 
 export const useBreakers = (filters: BreakerFilters) => {
   const { getAccessToken } = useAuth();
@@ -20,5 +30,72 @@ export const useBreakers = (filters: BreakerFilters) => {
       return response.data as Breaker[];
     },
     staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+};
+
+// --- create breaker ---
+type RegisterBreakerResult =
+  | { success: true; data: RegisterBreakerResponse }
+  | { success: false; error: string };
+
+export const registerBreaker = async (
+  payload: RegisterBreakerPayload,
+  token: string,
+): Promise<RegisterBreakerResult> => {
+  try {
+    const response = await axios.post<RegisterBreakerResponse>(
+      `${API_BASE_URL}/v1/api/breaker/service/register`,
+      payload,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (response.data.responsecode !== "000") {
+      return {
+        success: false,
+        error: response.data.responsedesc || "",
+      };
+    }
+
+    return {
+      success: true,
+      data: response.data,
+    };
+  } catch (error: unknown) {
+    return {
+      success: false,
+      error: handleApiError(error),
+    };
+  }
+};
+
+export const useRegisterBreaker = () => {
+  const { getAccessToken } = useAuth();
+  const token = getAccessToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: RegisterBreakerPayload) => {
+      if (!token) {
+        throw new Error("No token found in local storage");
+      }
+      const response = await registerBreaker(payload, token);
+      if (!response.success) {
+        throw new Error(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      // Invalidate and refetch the 'breakers' query to show the newly created breaker
+      queryClient.invalidateQueries({ queryKey: ["breakers"] });
+      console.log("Breaker registered successfully!");
+    },
+    onError: (error) => {
+      console.error("Error registering breaker:", error.message);
+    },
   });
 };

--- a/src/services/breakers-service.ts
+++ b/src/services/breakers-service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import axios, { type AxiosError } from "axios";
 import { env } from "@/env";
 import { handleApiError } from "error";
@@ -12,6 +13,25 @@ const API_BASE_URL = env.NEXT_PUBLIC_BASE_URL;
 type BreakersResult =
   | { success: true; data: Breaker[] }
   | { success: false; error: string };
+
+// Define the type for the data sent to the register breaker API
+export type RegisterBreakerPayload = {
+  sbcId: string;
+  state: string;
+  name: string;
+  breakerCount: number;
+  city: string;
+  streetName: string;
+  assetId: string;
+};
+
+// Define the type for the response from the register breaker API
+export type RegisterBreakerResponse = {
+  responsecode: string;
+  responsedesc: string;
+  responsedata: any; // Adjust this type based on the actual success response data
+};
+
 export const fetchBreakers = async (
   filters: BreakerFilters,
   token: string,


### PR DESCRIPTION
This commit introduces the functionality to register new breakers and addresses the "unique key" warning in the Breaker Management Table.

**Key Changes:**

- **Added Breaker Registration API Integration:**
    - Created `registerBreaker` service function in `src/services/breakers-service.ts` to handle `POST` requests to `/v1/api/breaker/service/register`.
    - Implemented `useRegisterBreaker` custom hook in `src/hooks/use-breakers.ts` using `@tanstack/react-query`'s `useMutation` for efficient asynchronous data submission and automatic cache invalidation.
    - Updated `CreateBreakerForm.tsx` to utilize `useRegisterBreaker` for form submission, including success/error toasts and form resetting.
    - Ensured `RegisterBreakerPayload` type in `src/services/breakers-service.ts` correctly matches backend's expected payload (`breakerCount: number`).
    - Handled conversion of `breakerCounter` (string from form) to `breakerCount` (number for API) during payload construction.

- **Resolved "Unique Key" Warning in `BreakerManagementTable`:**
    - Applied `key={breaker.id}` to the `React.Fragment` wrapping the main and expanded table rows within `src/components/breaker-management-table.tsx` to ensure each iterated group of rows has a unique identifier.

These changes improve the application's functionality by enabling breaker creation and enhance stability by resolving a critical React list rendering warning.